### PR TITLE
Story 9864/upgrade java v17

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=11
+java.runtime.version=17


### PR DESCRIPTION
https://app.shortcut.com/phpdev/story/9864/upgrade-metabase-staging

After pushing latest v of Metabase to staging, it was crashing with error:
>Exception in thread "main" java.lang.UnsupportedClassVersionError: org/eclipse/jetty/server/Server has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0


Class file version 55.0 = Java 11
Class file version 61.0 = Java 17


Updating Java version on Heroku with this PR per [instructions in our Readme](https://github.com/Performance-Health-Partners/performance-health-partners/blob/main/README-metabase.md#upgrading-metabase-java-version-on-heroku) to hopefully fix error.