### PR TITLE
upgrade to required java version

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=17
+java.runtime.version=21


### PR DESCRIPTION
https://app.shortcut.com/phpdev/story/12068/upgrade-metabase-staging-to-1-58-15-1

When jumping to v 1.58.15.1 of Metabase, the app crashed.

the error:

> Exception in thread "main" java.lang.NoSuchMethodError: 'java.util.concurrent.ExecutorService java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor()'


the reason:

> This error occurs because you are compiling or building your project with a newer version of Java (Java 21 or later), but you are attempting to run the application on an older version of Java (like Java 17 or earlier) that does not support virtual threads.
> The method Executors.newVirtualThreadPerTaskExecutor() was officially introduced in Java 21

From Metabase:
https://www.metabase.com/docs/latest/troubleshooting-guide/running
>Metabase should be run on Java version 21 (older versions are unsupported).

